### PR TITLE
Add Material Reporting endpoint for engineer materials

### DIFF
--- a/api/materialreport/config/routes.json
+++ b/api/materialreport/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/materialreports",
+      "handler": "Materialreport.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/materialreports/count",
+      "handler": "Materialreport.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/materialreports/:id",
+      "handler": "Materialreport.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/materialreports",
+      "handler": "Materialreport.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/materialreports/:id",
+      "handler": "Materialreport.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/materialreports/:id",
+      "handler": "Materialreport.destroy",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/materialreport/controllers/Materialreport.js
+++ b/api/materialreport/controllers/Materialreport.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Materialreport.js controller
+ *
+ * @description: A set of functions called "actions" for managing `Materialreport`.
+ */
+
+module.exports = {
+
+  /**
+   * Retrieve materialreport records.
+   *
+   * @return {Object|Array}
+   */
+
+  find: async (ctx, next, { populate } = {}) => {
+    if (ctx.query._q) {
+      return strapi.services.materialreport.search(ctx.query);
+    } else {
+      return strapi.services.materialreport.fetchAll(ctx.query, populate);
+    }
+  },
+
+  /**
+   * Retrieve a materialreport record.
+   *
+   * @return {Object}
+   */
+
+  findOne: async (ctx) => {
+    return strapi.services.materialreport.fetch(ctx.params);
+  },
+
+  /**
+   * Count materialreport records.
+   *
+   * @return {Number}
+   */
+
+  count: async (ctx, next, { populate } = {}) => {
+    return strapi.services.materialreport.count(ctx.query, populate);
+  },
+
+  /**
+   * Create a/an materialreport record.
+   *
+   * @return {Object}
+   */
+
+  create: async (ctx) => {
+    return strapi.services.materialreport.add(ctx.request.body);
+  },
+
+  /**
+   * Update a/an materialreport record.
+   *
+   * @return {Object}
+   */
+
+  update: async (ctx, next) => {
+    return strapi.services.materialreport.edit(ctx.params, ctx.request.body) ;
+  },
+
+  /**
+   * Destroy a/an materialreport record.
+   *
+   * @return {Object}
+   */
+
+  destroy: async (ctx, next) => {
+    return strapi.services.materialreport.remove(ctx.params);
+  }
+};

--- a/api/materialreport/documentation/2.0.26/overrides/materialreport.json
+++ b/api/materialreport/documentation/2.0.26/overrides/materialreport.json
@@ -1,0 +1,68 @@
+{
+  "paths": {
+    "/materialreports": {
+      "get": {
+        "description": "Get all Material Report entries",
+        "summary": "",
+        "tags": [
+          "Material Reports"
+        ],
+        "security": []
+      },
+      "post": {
+        "description": "Create a new Material Report entry",
+        "summary": "",
+        "tags": [
+          "Material Reports"
+        ],
+        "security": []
+      }
+    },
+    "/materialreports/count": {
+      "get": {
+        "description": "Get a count of all Material Report entries",
+        "summary": "",
+        "tags": [
+          "Material Reports"
+        ],
+        "security": []
+      }
+    },
+    "/materialreports/{id}": {
+      "get": {
+        "description": "Get a Material Report by id",
+        "summary": "",
+        "tags": [
+          "Material Reports"
+        ],
+        "security": []
+      },
+      "put": {
+        "description": "Update a Material Report by id",
+        "summary": "",
+        "tags": [
+          "Material Reports"
+        ],
+        "security": [
+          "updateLogWrite"
+        ]
+      },
+      "delete": {
+        "description": "Delete a Material Report by id",
+        "summary": "",
+        "tags": [
+          "Material Reports"
+        ],
+        "security": [
+          "updateLogWrite"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Material Reports",
+      "description": "Material reports for Engineering"
+    }
+  ]
+}

--- a/api/materialreport/models/Materialreport.js
+++ b/api/materialreport/models/Materialreport.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * Lifecycle callbacks for the `Materialreport` model.
+ */
+
+module.exports = {
+  // Before saving a value.
+  // Fired before an `insert` or `update` query.
+  // beforeSave: async (model, attrs, options) => {},
+
+  // After saving a value.
+  // Fired after an `insert` or `update` query.
+  // afterSave: async (model, response, options) => {},
+
+  // Before fetching a value.
+  // Fired before a `fetch` operation.
+  // beforeFetch: async (model, columns, options) => {},
+
+  // After fetching a value.
+  // Fired after a `fetch` operation.
+  // afterFetch: async (model, response, options) => {},
+  
+  // Before fetching all values.
+  // Fired before a `fetchAll` operation.
+  // beforeFetchAll: async (model, columns, options) => {},
+
+  // After fetching all values.
+  // Fired after a `fetchAll` operation.
+  // afterFetchAll: async (model, response, options) => {},
+
+  // Before creating a value.
+  // Fired before an `insert` query.
+  // beforeCreate: async (model, attrs, options) => {},
+
+  // After creating a value.
+  // Fired after an `insert` query.
+  // afterCreate: async (model, attrs, options) => {},
+
+  // Before updating a value.
+  // Fired before an `update` query.
+  // beforeUpdate: async (model, attrs, options) => {},
+
+  // After updating a value.
+  // Fired after an `update` query.
+  // afterUpdate: async (model, attrs, options) => {},
+
+  // Before destroying a value.
+  // Fired before a `delete` query.
+  // beforeDestroy: async (model, attrs, options) => {},
+
+  // After destroying a value.
+  // Fired after a `delete` query.
+  // afterDestroy: async (model, attrs, options) => {}
+};

--- a/api/materialreport/models/Materialreport.settings.json
+++ b/api/materialreport/models/Materialreport.settings.json
@@ -1,0 +1,49 @@
+{
+  "connection": "default",
+  "collectionName": "materialreports",
+  "info": {
+    "name": "materialreport",
+    "description": "Material reporting for engineering"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "comment": ""
+  },
+  "attributes": {
+    "system": {
+      "type": "string",
+      "required": true
+    },
+    "body": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    },
+    "journalName": {
+      "type": "string",
+      "required": true
+    },
+    "journalLocalised": {
+      "type": "string"
+    },
+    "count": {
+      "type": "integer"
+    },
+    "distanceFromMainStar": {
+      "type": "integer"
+    },
+    "playMode": {
+      "type": "string"
+    },
+    "isBeta": {
+      "default": false,
+      "type": "boolean"
+    },
+    "clientVersion": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/api/materialreport/models/Materialreport.settings.json
+++ b/api/materialreport/models/Materialreport.settings.json
@@ -18,6 +18,12 @@
     "body": {
       "type": "string"
     },
+    "latitude": {
+      "type": "float"
+    },
+    "longitude": {
+      "type": "float"
+    },
     "category": {
       "type": "string"
     },

--- a/api/materialreport/services/Materialreport.js
+++ b/api/materialreport/services/Materialreport.js
@@ -1,0 +1,209 @@
+/* global Materialreport */
+'use strict';
+
+/**
+ * Materialreport.js service
+ *
+ * @description: A set of functions similar to controller's actions to avoid code duplication.
+ */
+
+// Public dependencies.
+const _ = require('lodash');
+
+// Strapi utilities.
+const utils = require('strapi-hook-bookshelf/lib/utils/');
+const { convertRestQueryParams, buildQuery } = require('strapi-utils');
+
+
+module.exports = {
+
+  /**
+   * Promise to fetch all materialreports.
+   *
+   * @return {Promise}
+   */
+
+  fetchAll: (params, populate) => {
+    // Select field to populate.
+    const withRelated = populate || Materialreport.associations
+      .filter(ast => ast.autoPopulate !== false)
+      .map(ast => ast.alias);
+
+    const filters = convertRestQueryParams(params);
+
+    return Materialreport.query(buildQuery({ model: Materialreport, filters }))
+      .fetchAll({ withRelated })
+      .then(data => data.toJSON());
+  },
+
+  /**
+   * Promise to fetch a/an materialreport.
+   *
+   * @return {Promise}
+   */
+
+  fetch: (params) => {
+    // Select field to populate.
+    const populate = Materialreport.associations
+      .filter(ast => ast.autoPopulate !== false)
+      .map(ast => ast.alias);
+
+    return Materialreport.forge(_.pick(params, 'id')).fetch({
+      withRelated: populate
+    });
+  },
+
+  /**
+   * Promise to count a/an materialreport.
+   *
+   * @return {Promise}
+   */
+
+  count: (params) => {
+    // Convert `params` object to filters compatible with Bookshelf.
+    const filters = convertRestQueryParams(params);
+
+    return Materialreport.query(buildQuery({ model: Materialreport, filters: _.pick(filters, 'where') })).count();
+  },
+
+  /**
+   * Promise to add a/an materialreport.
+   *
+   * @return {Promise}
+   */
+
+  add: async (values) => {
+    // Extract values related to relational data.
+    const relations = _.pick(values, Materialreport.associations.map(ast => ast.alias));
+    const data = _.omit(values, Materialreport.associations.map(ast => ast.alias));
+
+    // Create entry with no-relational data.
+    const entry = await Materialreport.forge(data).save();
+
+    // Create relational data and return the entry.
+    return Materialreport.updateRelations({ id: entry.id , values: relations });
+  },
+
+  /**
+   * Promise to edit a/an materialreport.
+   *
+   * @return {Promise}
+   */
+
+  edit: async (params, values) => {
+    // Extract values related to relational data.
+    const relations = _.pick(values, Materialreport.associations.map(ast => ast.alias));
+    const data = _.omit(values, Materialreport.associations.map(ast => ast.alias));
+
+    // Create entry with no-relational data.
+    const entry = await Materialreport.forge(params).save(data);
+
+    // Create relational data and return the entry.
+    return Materialreport.updateRelations(Object.assign(params, { values: relations }));
+  },
+
+  /**
+   * Promise to remove a/an materialreport.
+   *
+   * @return {Promise}
+   */
+
+  remove: async (params) => {
+    params.values = {};
+    Materialreport.associations.map(association => {
+      switch (association.nature) {
+        case 'oneWay':
+        case 'oneToOne':
+        case 'manyToOne':
+        case 'oneToManyMorph':
+          params.values[association.alias] = null;
+          break;
+        case 'oneToMany':
+        case 'manyToMany':
+        case 'manyToManyMorph':
+          params.values[association.alias] = [];
+          break;
+        default:
+      }
+    });
+
+    await Materialreport.updateRelations(params);
+
+    return Materialreport.forge(params).destroy();
+  },
+
+  /**
+   * Promise to search a/an materialreport.
+   *
+   * @return {Promise}
+   */
+
+  search: async (params) => {
+    // Convert `params` object to filters compatible with Bookshelf.
+    const filters = strapi.utils.models.convertParams('materialreport', params);
+    // Select field to populate.
+    const populate = Materialreport.associations
+      .filter(ast => ast.autoPopulate !== false)
+      .map(ast => ast.alias);
+
+    const associations = Materialreport.associations.map(x => x.alias);
+    const searchText = Object.keys(Materialreport._attributes)
+      .filter(attribute => attribute !== Materialreport.primaryKey && !associations.includes(attribute))
+      .filter(attribute => ['string', 'text'].includes(Materialreport._attributes[attribute].type));
+
+    const searchInt = Object.keys(Materialreport._attributes)
+      .filter(attribute => attribute !== Materialreport.primaryKey && !associations.includes(attribute))
+      .filter(attribute => ['integer', 'decimal', 'float'].includes(Materialreport._attributes[attribute].type));
+
+    const searchBool = Object.keys(Materialreport._attributes)
+      .filter(attribute => attribute !== Materialreport.primaryKey && !associations.includes(attribute))
+      .filter(attribute => ['boolean'].includes(Materialreport._attributes[attribute].type));
+
+    const query = (params._q || '').replace(/[^a-zA-Z0-9.-\s]+/g, '');
+
+    return Materialreport.query(qb => {
+      if (!_.isNaN(_.toNumber(query))) {
+        searchInt.forEach(attribute => {
+          qb.orWhereRaw(`${attribute} = ${_.toNumber(query)}`);
+        });
+      }
+
+      if (query === 'true' || query === 'false') {
+        searchBool.forEach(attribute => {
+          qb.orWhereRaw(`${attribute} = ${_.toNumber(query === 'true')}`);
+        });
+      }
+
+      // Search in columns with text using index.
+      switch (Materialreport.client) {
+        case 'mysql':
+          qb.orWhereRaw(`MATCH(${searchText.join(',')}) AGAINST(? IN BOOLEAN MODE)`, `*${query}*`);
+          break;
+        case 'pg': {
+          const searchQuery = searchText.map(attribute =>
+            _.toLower(attribute) === attribute
+              ? `to_tsvector(${attribute})`
+              : `to_tsvector('${attribute}')`
+          );
+
+          qb.orWhereRaw(`${searchQuery.join(' || ')} @@ to_tsquery(?)`, query);
+          break;
+        }
+      }
+
+      if (filters.sort) {
+        qb.orderBy(filters.sort.key, filters.sort.order);
+      }
+
+      if (filters.skip) {
+        qb.offset(_.toNumber(filters.skip));
+      }
+
+      if (filters.limit) {
+        qb.limit(_.toNumber(filters.limit));
+      }
+    }).fetchAll({
+      withRelated: populate
+    });
+  }
+};


### PR DESCRIPTION
Request by CMDR Exigeous for the purpose of tracking material locations.

The plan is to cron delete entries older than a certain date but that will come later, likely in the CAPIv2-Updater project.