### PR TITLE
Auto update systems with EDSM data on Create/Update

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-engines true

--- a/api/system/services/System.js
+++ b/api/system/services/System.js
@@ -39,7 +39,6 @@ module.exports = {
 
       // Confirm that we actually need to ask EDSM for an update, if coords locked no reason to
       if (oldData.edsmCoordLocked === false || typeof oldData.edsmCoordLocked === 'undefined') {
-        console.log('break1');
         // Grabbing old System Name if not provided
         if (typeof values.systemName === 'undefined') {
           values.systemName = oldData.systemName;

--- a/api/system/services/System.js
+++ b/api/system/services/System.js
@@ -51,6 +51,17 @@ module.exports = {
         }
       }
     }
+
+    // Forcefully remove created_at
+    if (values.created_at) {
+      delete values.created_at;
+    }
+
+    // Forcefully remove updated_at
+    if (values.updated_at) {
+      delete values.updated_at;
+    }
+
     return strapi.query('System').update(params, values);
   },
 

--- a/api/system/services/System.js
+++ b/api/system/services/System.js
@@ -1,8 +1,104 @@
 'use strict';
+const fetch = require('node-fetch');
+
 
 /**
  * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/guides/services.html#core-services)
  * to customize this service
  */
 
-module.exports = {};
+module.exports = {
+  /**
+   * Promise to add record
+   *
+   * @return {Promise}
+   */
+
+  create: async (values) => {
+    let edsmData = await strapi.services.system.edsmUpdate(values);
+
+    return strapi.query('System').create(edsmData);
+  },
+
+  /**
+   * Promise to edit record
+   *
+   * @return {Promise}
+   */
+
+  update: async (params, values) => {
+
+    let oldData = await strapi.services.system.findOne({id: params.id});
+    oldData = oldData.toJSON();
+
+    if (oldData.edsmCoordLocked == false || oldData.edsmCoordLocked == undefined) {
+      if (values.systemName == undefined) {
+        values.systemName = oldData.systemName;
+      }
+      values.missingSkipCount = oldData.missingSkipCount;
+
+      let edsmData = await strapi.services.system.edsmUpdate(values);
+
+      return strapi.query('System').update(params, edsmData);
+    }
+
+    return strapi.query('System').update(params, values);
+  },
+
+  /**
+   * Promise to fetch a system from EDSM to update a local record
+   *
+   * @return {Promise}
+   */
+  edsmUpdate: async (values) => {
+    const edsmAPISystem = 'https://www.edsm.net/api-v1/system?showId=1&showCoordinates=1&showPrimaryStar=1';
+
+    const getData = async system => {
+      try {
+        const response = await fetch(edsmAPISystem + '&systemName=' + encodeURIComponent(system));
+        const json = await response.json();
+        return json;
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    let newValues = values;
+    let newData = {};
+    if (newValues.missingSkipCount >= 10 ) {
+      newValues.systemName = newValues.systemName.toUpperCase();
+      return newValues;
+    } else {
+      newData = await getData(values.systemName);
+    }
+
+    if (newData != undefined) {
+
+      newValues.systemName = newData.name.toUpperCase();
+
+      if (newData.id) {
+        newValues.edsmID = newData.id;
+      }
+      if (newData.id64) {
+        newValues.ID64 = newData.id64;
+      }
+      if (newData.coords) {
+        newValues.edsmCoordX = newData.coords.x;
+        newValues.edsmCoordY = newData.coords.y;
+        newValues.edsmCoordZ = newData.coords.z;
+      }
+      if (newData.coordsLocked) {
+        newValues.edsmCoordLocked = newData.coordsLocked;
+      }
+      if (newData.primaryStar) {
+        newValues.primaryStar = newData.primaryStar;
+      }
+      newValues.missingSkipCount = 0;
+      return newValues;
+    } else {
+      newValues.missingSkipCount = (newValues.missingSkipCount + 1) || 1;
+      newValues.systemName = newValues.systemName.toUpperCase();
+      return newValues;
+    }
+  },
+};

--- a/api/system/services/System.js
+++ b/api/system/services/System.js
@@ -9,7 +9,6 @@ module.exports = {
    */
 
   create: async values => {
-
     // Query EDSM for systems data when a new system is added
     // This should be moved to lifecycle callbacks to prevent blocking code
     try {
@@ -27,17 +26,17 @@ module.exports = {
    */
 
   update: async (params, values) => {
-
     // If there is no edsmCoordLocked in values, try to grab data from EDSM
     try {
       // This is used to allow the CAPIv2-Updater to bypass this as it already grabs data from EDSM
-      if (!values.edsmCoordLocked) {
+      if (typeof values.edsmCoordLocked === 'undefined') {
         // Grabbing old data in case we need something that wasn't provided like missingSkipCount
         let oldData = await strapi.services.system.findOne({ id: params.id });
         oldData = oldData.toJSON();
 
         // Confirm that we actually need to ask EDSM for an update, if coords locked no reason to
         if (oldData.edsmCoordLocked === false || typeof oldData.edsmCoordLocked === 'undefined') {
+          console.log('break1');
           // Grabbing old System Name if not provided
           if (typeof values.systemName === 'undefined') {
             values.systemName = oldData.systemName;
@@ -48,9 +47,8 @@ module.exports = {
 
           return strapi.query('System').update(params, edsmData);
         }
-      } else {
-        return strapi.query('System').update(params, values);
       }
+      return strapi.query('System').update(params, values);
     } catch (error) {
       console.log(error);
     }
@@ -79,7 +77,7 @@ module.exports = {
     // Copying object values into a temporary object as to not mess with values
     let newValues = {
       systemName: values.systemName,
-      missingSkipCount: values.missingSkipCount
+      missingSkipCount: values.missingSkipCount,
     };
 
     // Init edsmData
@@ -116,9 +114,7 @@ module.exports = {
       }
       newValues.missingSkipCount = 0;
       return newValues;
-
     } else {
-
       // If EDSM doesn't have the data, increase the skip count and proceed
       newValues.missingSkipCount = newValues.missingSkipCount + 1 || 1;
       newValues.systemName = newValues.systemName.toUpperCase();

--- a/api/system/services/System.js
+++ b/api/system/services/System.js
@@ -28,18 +28,20 @@ module.exports = {
 
   update: async (params, values) => {
 
-    let oldData = await strapi.services.system.findOne({id: params.id});
-    oldData = oldData.toJSON();
+    if (!values.edsmCoordLocked){
+      let oldData = await strapi.services.system.findOne({id: params.id});
+      oldData = oldData.toJSON();
 
-    if (oldData.edsmCoordLocked == false || oldData.edsmCoordLocked == undefined) {
-      if (values.systemName == undefined) {
-        values.systemName = oldData.systemName;
+      if (oldData.edsmCoordLocked == false || oldData.edsmCoordLocked == undefined) {
+        if (values.systemName == undefined) {
+          values.systemName = oldData.systemName;
+        }
+        values.missingSkipCount = oldData.missingSkipCount;
+
+        let edsmData = await strapi.services.system.edsmUpdate(values);
+
+        return strapi.query('System').update(params, edsmData);
       }
-      values.missingSkipCount = oldData.missingSkipCount;
-
-      let edsmData = await strapi.services.system.edsmUpdate(values);
-
-      return strapi.query('System').update(params, edsmData);
     }
 
     return strapi.query('System').update(params, values);

--- a/api/system/services/System.js
+++ b/api/system/services/System.js
@@ -27,31 +27,31 @@ module.exports = {
 
   update: async (params, values) => {
     // If there is no edsmCoordLocked in values, try to grab data from EDSM
-    try {
-      // This is used to allow the CAPIv2-Updater to bypass this as it already grabs data from EDSM
-      if (typeof values.edsmCoordLocked === 'undefined') {
-        // Grabbing old data in case we need something that wasn't provided like missingSkipCount
-        let oldData = await strapi.services.system.findOne({ id: params.id });
-        oldData = oldData.toJSON();
+    // This is used to allow the CAPIv2-Updater to bypass this as it already grabs data from EDSM
+    if (typeof values.edsmCoordLocked === 'undefined') {
+      // Grabbing old data in case we need something that wasn't provided like missingSkipCount
+      let oldData = await strapi.services.system.findOne({ id: params.id });
+      oldData = oldData.toJSON();
 
-        // Confirm that we actually need to ask EDSM for an update, if coords locked no reason to
-        if (oldData.edsmCoordLocked === false || typeof oldData.edsmCoordLocked === 'undefined') {
-          console.log('break1');
-          // Grabbing old System Name if not provided
-          if (typeof values.systemName === 'undefined') {
-            values.systemName = oldData.systemName;
-          }
-          values.missingSkipCount = oldData.missingSkipCount;
+      // Confirm that we actually need to ask EDSM for an update, if coords locked no reason to
+      if (oldData.edsmCoordLocked === false || typeof oldData.edsmCoordLocked === 'undefined') {
+        console.log('break1');
+        // Grabbing old System Name if not provided
+        if (typeof values.systemName === 'undefined') {
+          values.systemName = oldData.systemName;
+        }
+        values.missingSkipCount = oldData.missingSkipCount;
 
+        // Grabbing EDSM data and pushing it into the values to save
+        try {
           let edsmData = await strapi.services.system.edsmUpdate(values);
-
           return strapi.query('System').update(params, edsmData);
+        } catch (error) {
+          console.log(error);
         }
       }
-      return strapi.query('System').update(params, values);
-    } catch (error) {
-      console.log(error);
     }
+    return strapi.query('System').update(params, values);
   },
 
   /**

--- a/api/system/services/System.js
+++ b/api/system/services/System.js
@@ -9,13 +9,17 @@ module.exports = {
    */
 
   create: async values => {
-    // Query EDSM for systems data when a new system is added
+    // Query EDSM for systems data when a new system is added if no edsmID is present
     // This should be moved to lifecycle callbacks to prevent blocking code
-    try {
-      let edsmData = await strapi.services.system.edsmUpdate(values);
-      return strapi.query('System').create(edsmData);
-    } catch (error) {
-      console.log(error);
+    if (typeof values.edsmID === 'undefined') {
+      try {
+        let edsmData = await strapi.services.system.edsmUpdate(values);
+        return strapi.query('System').create(edsmData);
+      } catch (error) {
+        console.log(error);
+      }
+    } else {
+      return strapi.query('System').create(values);
     }
   },
 
@@ -26,9 +30,9 @@ module.exports = {
    */
 
   update: async (params, values) => {
-    // If there is no edsmCoordLocked in values, try to grab data from EDSM
+    // If there is no edsmID in values, try to grab data from EDSM
     // This is used to allow the CAPIv2-Updater to bypass this as it already grabs data from EDSM
-    if (typeof values.edsmCoordLocked === 'undefined') {
+    if (typeof values.edsmID === 'undefined') {
       // Grabbing old data in case we need something that wasn't provided like missingSkipCount
       let oldData = await strapi.services.system.findOne({ id: params.id });
       oldData = oldData.toJSON();

--- a/api/system/services/System.js
+++ b/api/system/services/System.js
@@ -29,8 +29,8 @@ module.exports = {
         let oldData = await strapi.services.system.findOne({ id: params.id });
         oldData = oldData.toJSON();
 
-        if (oldData.edsmCoordLocked == false || oldData.edsmCoordLocked == undefined) {
-          if (values.systemName == undefined) {
+        if (oldData.edsmCoordLocked === false || typeof oldData.edsmCoordLocked === 'undefined') {
+          if (typeof values.systemName === 'undefined') {
             values.systemName = oldData.systemName;
           }
           values.missingSkipCount = oldData.missingSkipCount;
@@ -39,9 +39,9 @@ module.exports = {
 
           return strapi.query('System').update(params, edsmData);
         }
+      } else {
+        return strapi.query('System').update(params, values);
       }
-
-      return strapi.query('System').update(params, values);
     } catch (error) {
       console.log(error);
     }
@@ -65,34 +65,37 @@ module.exports = {
       }
     };
 
-    let newValues = values;
-    let newData = {};
+    let newValues = {
+      systemName: values.systemName,
+      missingSkipCount: values.missingSkipCount
+    };
+    let edsmData = {};
     if (newValues.missingSkipCount >= 10) {
       newValues.systemName = newValues.systemName.toUpperCase();
       return newValues;
     } else {
-      newData = await getData(values.systemName);
+      edsmData = await getData(values.systemName);
     }
 
-    if (newData != undefined) {
-      newValues.systemName = newData.name.toUpperCase();
+    if (typeof edsmData !== 'undefined') {
+      newValues.systemName = edsmData.name.toUpperCase();
 
-      if (newData.id) {
-        newValues.edsmID = newData.id;
+      if (edsmData.id) {
+        newValues.edsmID = edsmData.id;
       }
-      if (newData.id64) {
-        newValues.ID64 = newData.id64;
+      if (edsmData.id64) {
+        newValues.ID64 = edsmData.id64;
       }
-      if (newData.coords) {
-        newValues.edsmCoordX = newData.coords.x;
-        newValues.edsmCoordY = newData.coords.y;
-        newValues.edsmCoordZ = newData.coords.z;
+      if (edsmData.coords) {
+        newValues.edsmCoordX = edsmData.coords.x;
+        newValues.edsmCoordY = edsmData.coords.y;
+        newValues.edsmCoordZ = edsmData.coords.z;
       }
-      if (newData.coordsLocked) {
-        newValues.edsmCoordLocked = newData.coordsLocked;
+      if (edsmData.coordsLocked) {
+        newValues.edsmCoordLocked = edsmData.coordsLocked;
       }
-      if (newData.primaryStar) {
-        newValues.primaryStar = newData.primaryStar;
+      if (edsmData.primaryStar) {
+        newValues.primaryStar = edsmData.primaryStar;
       }
       newValues.missingSkipCount = 0;
       return newValues;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lodash": "^4.17.5",
     "moment": "^2.24.0",
     "mysql": "2.17.1",
+    "node-fetch": "^2.6.0",
     "strapi": "3.0.0-beta.15",
     "strapi-admin": "3.0.0-beta.15",
     "strapi-hook-bookshelf": "3.0.0-beta.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,7 +7101,7 @@ node-fetch@^1.0.1, node-fetch@^1.7.3:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.1.2, node-fetch@^2.2.0:
+node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==


### PR DESCRIPTION
Pending feedback but the point of this is to query EDSM directly from the CAPIv2 when a new system is added or updated.

I did add a bypass to the update function where if the `edsmCoordLocked` is sent it will bypass EDSM. This is for the updater when we use it to update a lot of systems at once.

TODO:

Add a cron that resets the `missingSkipCount` on all systems that have a value greater than 10 once a month.